### PR TITLE
Fix the starknet error

### DIFF
--- a/Airdrop_account_manageme.gs
+++ b/Airdrop_account_manageme.gs
@@ -93,7 +93,7 @@ function getStarknetInfoFromViewblock() {
   var range = sheet.getRange(startColumn,  20, maxValueInColumn, 3);
   range.clearContent();
   for (var i = startColumn; i <= maxValueInColumn; i++) {
-    var address = sheet.getRange(i, 3).getValue();
+    var address = sheet.getRange(i, 3).getValue().toLowerCase();
     if (address == '') {
       continue
     }


### PR DESCRIPTION
The agent wallet supports both uppercase and lowercase addresses, while the StarkNet API only supports lowercase. Adding a function should fix the issue.